### PR TITLE
Fix assertion failure in NullEvent::setCompute with small G values

### DIFF
--- a/htsim/sim/logsim-interface.cpp
+++ b/htsim/sim/logsim-interface.cpp
@@ -8,6 +8,8 @@
 #include "lgs/TimelineVisualization.hpp"
 #include "lgs/cmdline.h"
 #include <chrono>
+#include <cmath>
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <functional>
@@ -222,6 +224,11 @@ void LogSimInterface::htsim_simulate_until(int64_t until) {
     //printf("Running HTSIM Simulate Until %lu - HtSime Time is %lu\n", until, htsim_api->getGlobalTimeNs());
 
     if (until != -1) {
+      // Clamp to at least current HTSIM time to avoid scheduling in the past
+      int64_t htsim_now_ns = static_cast<int64_t>(htsim_api->getGlobalTimeNs());
+      if (until < htsim_now_ns) {
+          until = htsim_now_ns;
+      }
       compute_started++;
       null_events_handler->setCompute(until);
     }
@@ -656,7 +663,8 @@ int start_lgs(std::string filename_goal, LogSimInterface &lgs) {
                   int updated_size = (num_packets+1) * 4160; // Parameterize this. This accounts for the header size
                   elem.size = updated_size;
 
-                  uint64_t bandwidth_cost2 = static_cast<uint64_t>((elem.size) * G);
+                  uint64_t bandwidth_cost2 = std::max(static_cast<uint64_t>(1),
+                                                       static_cast<uint64_t>(std::ceil((double)(elem.size) * G)));
                   nextgs[elem.host][elem.nic] = elem.time + g + bandwidth_cost2; 
                   can_simulate_until = nextgs[elem.host][elem.nic];
 

--- a/htsim/sim/null_event.cpp
+++ b/htsim/sim/null_event.cpp
@@ -25,7 +25,12 @@ void NullEvent::doNextEvent() {
 }
 
 void NullEvent::setCompute(simtime_picosec computation_time) {
-    eventlist().sourceIsPendingRel(*this, computation_time * 1000 - eventlist().now()); // ns to ps
+    simtime_picosec target_ps = computation_time * 1000; // ns to ps
+    simtime_picosec now_ps = eventlist().now();
+    // Guard against truncation from ns/ps round-trip: if target is at or
+    // before current time, schedule immediately instead of underflowing.
+    simtime_picosec rel = (target_ps > now_ps) ? (target_ps - now_ps) : 0;
+    eventlist().sourceIsPendingRel(*this, rel);
 }
 
 void NullEvent::startComputations() { eventlist().doNextEvent(); }


### PR DESCRIPTION
## Problem

When the LogGOPSim `G` parameter is set to a small value (e.g., 0.0001), the simulation:
1. Crashes with `Assertion 'when >= now()' failed` in `EventList::sourceIsPending()`
2. Runs extremely slowly due to send pileups

## Root Cause

`getGlobalTimeNs()` returns `eventlist().now() / 1000`, integer division that **truncates** sub-nanosecond precision. When this truncated value flows back through `NullEvent::setCompute(ns_value)` which does `ns_value * 1000`, the round-tripped picosecond value is **smaller** than `eventlist().now()`, causing an unsigned underflow that schedules events in the past.

## Fixes

1. **`null_event.cpp`**: Guard against unsigned underflow by clamping the relative offset to 0 when target time ≤ now
2. **`logsim-interface.cpp` (`htsim_simulate_until`)**: Clamp `until` to at least current HTSIM time before scheduling
3. **`logsim-interface.cpp` (OP_SEND)**: Use `std::ceil` + `std::max(1,...)` for `bandwidth_cost2` so it never truncates to 0